### PR TITLE
KIN-201 Template category form

### DIFF
--- a/app/Views/admin/categories/CategoryCreate.php
+++ b/app/Views/admin/categories/CategoryCreate.php
@@ -25,77 +25,8 @@
                             <i class="ri-arrow-left-fill label-icon align-middle rounded-pill fs-16 me-2"></i>Volver
                         </a>
                     </div>
-                    <div class="row">
-                        <div class="col-md-6">
-                            <div class="card">
-                                <div class="card-header">
-                                    <label class="form-label mb-0" for="category-title-input">
-                                        <h5 class="card-title mb-0">Titulo de la categoría</h5>
-                                    </label>
-                                </div>
-                                <div class="card-body">
-                                    <div class="hstack gap-3 align-items-start">
-                                        <input type="text" class="form-control" name="category_title" id="category-title-input" value="" placeholder="Ingrese el título" required>
-                                    </div>
-                                </div>
-                            </div>
-                        </div>
-                        <!-- end col -->
-                        <div class="col-md-6">
-                            <div class="card">
-                                <div class="card-header">
-                                    <h5 class="card-title mb-0">Tags de la categoría</h5>
-                                </div>
-                                <div class="card-body">
-                                    <div class="hstack gap-3 align-items-start">
-                                        <div class="flex-grow-1">
-                                            <input class="form-control" name="category_tags" id="choices-text-remove-button" data-choices data-choices-multiple-remove="true" type="text"/>
-                                        </div>
-                                    </div>
-                                </div>
-                                <!-- end card body -->
-                            </div>
-                            <!-- end card -->
-                        </div>
-                        <!-- end col -->
-                    </div>
-                    <!-- end row -->
 
-                    <div class="row">
-                        <div class="col-md-12">
-                            <div class="card">
-                                <div class="card-header">
-                                    <h4 class="card-title mb-0">Icono</h4>
-                                </div><!-- end card header -->
-
-                                <div class="card-body">
-                                    <input type="file" class="filepond filepond-input-multiple" name="category_icon" data-allow-reorder="true" data-max-file-size="3MB" data-max-files="3">
-                                </div>
-                                <!-- end card body -->
-                            </div>
-                            <!-- end card -->
-                        </div>
-                        <!-- end col -->
-                    </div>
-                    <!-- end row -->
-
-                    <div class="row">
-                        <div class="col-md-12">
-                            <div class="card">
-                                <div class="card-header">
-                                    <h4 class="card-title mb-0">Imagen de fondo</h4>
-                                </div><!-- end card header -->
-
-                                <div class="card-body">
-                                    <input type="file" class="filepond filepond-input-multiple" name="category_bgImg" data-allow-reorder="true" data-max-file-size="3MB" data-max-files="3">
-                                </div>
-                                <!-- end card body -->
-                            </div>
-                            <!-- end card -->
-                        </div>
-                        <!-- end col -->
-                    </div>
-                    <!-- end row -->
+                    <?= $this->include('templates/admin/categoriesFormTemplate') ?>
 
                     <div class="text-end mb-3">
                         <button type="submit" class="btn btn-primary w-lg">Guardar</button>

--- a/app/Views/admin/categories/CategoryCreate.php
+++ b/app/Views/admin/categories/CategoryCreate.php
@@ -26,7 +26,7 @@
                         </a>
                     </div>
 
-                    <?= $this->include('templates/admin/categoriesFormTemplate') ?>
+                    <?= $this->include('admin/categories/categoriesFormTemplate') ?>
 
                     <div class="text-end mb-3">
                         <button type="submit" class="btn btn-primary w-lg">Guardar</button>

--- a/app/Views/admin/categories/categoriesFormTemplate.php
+++ b/app/Views/admin/categories/categoriesFormTemplate.php
@@ -8,7 +8,7 @@
             </div>
             <div class="card-body">
                 <div class="hstack gap-3 align-items-start">
-                    <input type="text" class="form-control" name="category_title" id="category-title-input" value="<?= $category["name"] ?? "";?>" placeholder="Ingrese el título" required>
+                    <input type="text" class="form-control" name="name" id="name" value="<?= $category["name"] ?? "";?>" placeholder="Ingrese el título" required>
                 </div>
             </div>
         </div>
@@ -22,7 +22,7 @@
             <div class="card-body">
                 <div class="hstack gap-3 align-items-start">
                     <div class="flex-grow-1">
-                        <input class="form-control" name="category_tags" id="choices-text-remove-button" data-choices data-choices-multiple-remove="true" type="text" value="<?= $category["tags"] ?? "";?>"/>
+                        <input class="form-control" name="tags" id="choices-text-remove-button" data-choices data-choices-multiple-remove="true" type="text" value="<?= $category["tags"] ?? "";?>"/>
                     </div>
                 </div>
             </div>
@@ -42,7 +42,7 @@
             </div><!-- end card header -->
 
             <div class="card-body">
-                <input type="file" class="filepond filepond-input-multiple" name="category_icon" data-allow-reorder="true" data-max-file-size="3MB" data-max-files="3">
+                <input type="file" class="filepond filepond-input-multiple" name="icon" data-allow-reorder="true" data-max-file-size="3MB" data-max-files="3">
             </div>
             <!-- end card body -->
         </div>
@@ -60,7 +60,7 @@
             </div><!-- end card header -->
 
             <div class="card-body">
-                <input type="file" class="filepond filepond-input-multiple" name="category_bgImg" data-allow-reorder="true" data-max-file-size="3MB" data-max-files="3">
+                <input type="file" class="filepond filepond-input-multiple" name="image" data-allow-reorder="true" data-max-file-size="3MB" data-max-files="3">
             </div>
             <!-- end card body -->
         </div>

--- a/app/Views/templates/admin/categoriesFormTemplate.php
+++ b/app/Views/templates/admin/categoriesFormTemplate.php
@@ -8,7 +8,7 @@
             </div>
             <div class="card-body">
                 <div class="hstack gap-3 align-items-start">
-                    <input type="text" class="form-control" name="category_title" id="category-title-input" value="<?= $category["title"] ?? "";?>" placeholder="Ingrese el título" required>
+                    <input type="text" class="form-control" name="category_title" id="category-title-input" value="<?= $category["name"] ?? "";?>" placeholder="Ingrese el título" required>
                 </div>
             </div>
         </div>

--- a/app/Views/templates/admin/categoriesFormTemplate.php
+++ b/app/Views/templates/admin/categoriesFormTemplate.php
@@ -1,0 +1,71 @@
+<div class="row">
+    <div class="col-md-6">
+        <div class="card">
+            <div class="card-header">
+                <label class="form-label mb-0" for="category-title-input">
+                    <h5 class="card-title mb-0">Titulo de la categoría</h5>
+                </label>
+            </div>
+            <div class="card-body">
+                <div class="hstack gap-3 align-items-start">
+                    <input type="text" class="form-control" name="category_title" id="category-title-input" value="<?= $category["title"] ?? "";?>" placeholder="Ingrese el título" required>
+                </div>
+            </div>
+        </div>
+    </div>
+    <!-- end col -->
+    <div class="col-md-6">
+        <div class="card">
+            <div class="card-header">
+                <h5 class="card-title mb-0">Tags de la categoría</h5>
+            </div>
+            <div class="card-body">
+                <div class="hstack gap-3 align-items-start">
+                    <div class="flex-grow-1">
+                        <input class="form-control" name="category_tags" id="choices-text-remove-button" data-choices data-choices-multiple-remove="true" type="text" value="<?= $category["tags"] ?? "";?>"/>
+                    </div>
+                </div>
+            </div>
+            <!-- end card body -->
+        </div>
+        <!-- end card -->
+    </div>
+    <!-- end col -->
+</div>
+<!-- end row -->
+
+<div class="row">
+    <div class="col-md-12">
+        <div class="card">
+            <div class="card-header">
+                <h4 class="card-title mb-0">Icono</h4>
+            </div><!-- end card header -->
+
+            <div class="card-body">
+                <input type="file" class="filepond filepond-input-multiple" name="category_icon" data-allow-reorder="true" data-max-file-size="3MB" data-max-files="3">
+            </div>
+            <!-- end card body -->
+        </div>
+        <!-- end card -->
+    </div>
+    <!-- end col -->
+</div>
+<!-- end row -->
+
+<div class="row">
+    <div class="col-md-12">
+        <div class="card">
+            <div class="card-header">
+                <h4 class="card-title mb-0">Imagen de fondo</h4>
+            </div><!-- end card header -->
+
+            <div class="card-body">
+                <input type="file" class="filepond filepond-input-multiple" name="category_bgImg" data-allow-reorder="true" data-max-file-size="3MB" data-max-files="3">
+            </div>
+            <!-- end card body -->
+        </div>
+        <!-- end card -->
+    </div>
+    <!-- end col -->
+</div>
+<!-- end row -->


### PR DESCRIPTION
[![KIN-201](https://badgen.net/badge/JIRA/KIN-201/blue)](https://loopcrack.atlassian.net/browse/KIN-201) ![Small](https://badgen.net/badge/PR%20Size/Small/green) [<img width="16" alt="Powered by Pull Request Badge" src="https://user-images.githubusercontent.com/1393946/111216524-d2bb8e00-85d4-11eb-821b-ed4c00989c02.png">](https://pullrequestbadge.com/?utm_medium=github&utm_source=loopcrack-org&utm_campaign=badge_info)<!-- PR-BADGE: PLEASE DO NOT REMOVE THIS COMMENT -->

The template category form was created

## Summary

### Problem

As developers, we want to not repeat the code and be able to reuse the same form both to create and edit categories.

### Solution

Create a template for the create and edit category form.

## Acceptance Criteria

### Requirements checklist

The form must get the next information:

- [x] Category name
- [x] Related category icon
- [x] Category image, which will be useful for the header of the product catalog page. The input must be a drag a drop
- [x] Category tags

### Testing

- [x] The create category form must be correct.
- [x] In the viewCategoryCreate method of CtrlCategory send an array with the information that you want the inputs to display and this must be able to be displayed in the view. For example: [ "category" => ["title" => "Telemetry", "tags" => "tag1,tag2"] ]

[KIN-201]: https://loopcrack.atlassian.net/browse/KIN-201?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ