### PR TITLE
KIN-279 configuration fixes and logic changes

### DIFF
--- a/app/Controllers/CtrlEmail.php
+++ b/app/Controllers/CtrlEmail.php
@@ -3,168 +3,173 @@
 namespace App\Controllers;
 
 use App\Models\EmailModel;
-use App\Utils\EmailSender; 
 use App\Models\UserModel;
+use App\Utils\EmailSender;
 use App\Validation\ContactEmailValidation;
 use App\Validation\PasswordEmailValidation;
 use App\Validation\SupportEmailValidation;
 use CodeIgniter\HTTP\RedirectResponse;
 use Exception;
+use Throwable;
+
 class CtrlEmail extends BaseController
 {
     public function sendContactEmail(): RedirectResponse
     {
         $contactEmailValidation = new ContactEmailValidation();
-        $POST = $this->request->getPost();
+        $POST                   = $this->request->getPost();
 
-        if (!$contactEmailValidation->validateData($POST)) {
-            return redirect()->back()->withInput()->with("errors", $contactEmailValidation->getErrors());
+        if (! $contactEmailValidation->validateData($POST)) {
+            return redirect()->back()->withInput()->with('errors', $contactEmailValidation->getErrors());
         }
 
-        $subject = "Mensaje del formulario de contacto";
+        $subject  = 'Mensaje del formulario de contacto';
         $formData = [
-            "product-name" => [
-                "label" => "Producto",
-                "output" => $POST["product-name"]
+            'product-name' => [
+                'label'  => 'Producto',
+                'output' => $POST['product-name'],
             ],
-            "message" => [
-                "label" => "Mensaje",
-                "output" => $POST["message"]
+            'message' => [
+                'label'  => 'Mensaje',
+                'output' => $POST['message'],
             ],
-            "customer" => [
-                "label" => "Nombre del cliente",
-                "output" => $POST["inquirer-name"]
-            ]
+            'customer' => [
+                'label'  => 'Nombre del cliente',
+                'output' => $POST['inquirer-name'],
+            ],
         ];
 
-        $successEmail =  EmailSender::sendEmail($POST["inquirer-name"], $POST['inquirer-email'], "kinub_admin@gmail.com", $subject, "mailDetail", $formData);
+        $successEmail = EmailSender::sendEmail($POST['inquirer-name'], $POST['inquirer-email'], 'kinub_admin@gmail.com', $subject, 'mailDetail', $formData);
 
         if ($successEmail) {
             $response = [
-                "title" => "Envío exitoso",
-                "message" => "Se ha enviado correctamente",
-                "type" => "success",
+                'title'   => 'Envío exitoso',
+                'message' => 'Se ha enviado correctamente',
+                'type'    => 'success',
             ];
             $emailModel = new EmailModel();
-            $data = [
-                "emailTypeId" => 1,
-                "emailContent" => json_encode($POST)
+            $data       = [
+                'emailTypeId'  => 1,
+                'emailContent' => EmailSender::getEmailBody($formData, 'mailDetail'),
             ];
             $emailModel->insert($data);
         } else {
             $response = [
-                "title" => "Envío fallido",
-                "message" => "No se pudo realizar el envío del email",
-                "type" => "error",
+                'title'   => 'Envío fallido',
+                'message' => 'No se pudo realizar el envío del email',
+                'type'    => 'error',
             ];
         }
 
-        return redirect()->back()->with("response", $response);
+        return redirect()->back()->with('response', $response);
     }
-
 
     public function sendSupportEmail(): RedirectResponse
     {
         $supportEmailValidation = new SupportEmailValidation();
-        $POST = $this->request->getPost();
-        if (!$supportEmailValidation->validateData($POST)) {
-            return redirect()->back()->withInput()->with("errors", $supportEmailValidation->getErrors());
+        $POST                   = $this->request->getPost();
+        if (! $supportEmailValidation->validateData($POST)) {
+            return redirect()->back()->withInput()->with('errors', $supportEmailValidation->getErrors());
         }
-        $subject = "Mensaje del formulario de soporte técnico";
+        $subject  = 'Mensaje del formulario de soporte técnico';
         $formData = [
-            "support-phone" => [
-                "label" => "Teléfono",
-                "output" => $POST["support-phone"]
+            'support-phone' => [
+                'label'  => 'Teléfono',
+                'output' => $POST['support-phone'],
             ],
-            "support-model" => [
-                "label" => "Modelo del producto",
-                "output" => $POST["support-model"]
+            'support-model' => [
+                'label'  => 'Modelo del producto',
+                'output' => $POST['support-model'],
             ],
-            "support-serial" => [
-                "label" => "Número de serie del producto",
-                "output" => $POST["support-serial"]
+            'support-serial' => [
+                'label'  => 'Número de serie del producto',
+                'output' => $POST['support-serial'],
             ],
-            "support-problem-type" => [
-                "label" => "Tipo de problema",
-                "output" => $POST["support-problem-type"]
+            'support-problem-type' => [
+                'label'  => 'Tipo de problema',
+                'output' => $POST['support-problem-type'],
             ],
-            "support-problem" => [
-                "label" => "Problema",
-                "output" => $POST["support-problem"]
+            'support-problem' => [
+                'label'  => 'Problema',
+                'output' => $POST['support-problem'],
             ],
-            "customer" => [
-                "label" => "Nombre del cliente",
-                "output" => $POST["support-customer"]
-            ]
+            'customer' => [
+                'label'  => 'Nombre del cliente',
+                'output' => $POST['support-customer'],
+            ],
         ];
 
-        $successEmail = EmailSender::sendEmail($POST["support-customer"],$POST['support-email'],"kinub_admin@gmail.com", $subject, "mailDetail", $formData );
+        $successEmail = EmailSender::sendEmail($POST['support-customer'], $POST['support-email'], 'kinub_admin@gmail.com', $subject, 'mailDetail', $formData);
 
-        if($successEmail){
+        if ($successEmail) {
             $response = [
-                "title" => "Envío exitoso",
-                "message" => "Se ha enviado correctamente",
-                "type" => "success",
+                'title'   => 'Envío exitoso',
+                'message' => 'Se ha enviado correctamente',
+                'type'    => 'success',
             ];
             $emailModel = new EmailModel();
-            $data = [
-                "emailTypeId" => 2,
-                "emailContent" => json_encode($POST)
+            $data       = [
+                'emailTypeId'  => 2,
+                'emailContent' => EmailSender::getEmailBody($formData, 'mailDetail'),
             ];
             $emailModel->insert($data);
-        }else{
+        } else {
             $response = [
-                "title" => "Envío fallido",
-                "message" => "No se pudo realizar el envío del email",
-                "type" => "error",
+                'title'   => 'Envío fallido',
+                'message' => 'No se pudo realizar el envío del email',
+                'type'    => 'error',
             ];
         }
 
-        return redirect()->back()->with("response", $response);
+        return redirect()->back()->with('response', $response);
     }
 
     public function sendEmailToResetPassword()
     {
         $validateEmail = new PasswordEmailValidation();
-        $data = $this->request->getPost();
+        $data          = $this->request->getPost();
 
         try {
-            if (!$validateEmail->validateInputs($data)) throw new Exception();
+            if (! $validateEmail->validateInputs($data)) {
+                throw new Exception();
+            }
 
             $userModel = new UserModel();
-            $user = $userModel->where("userEmail", $data['email'])->first();
+            $user      = $userModel->where('userEmail', $data['email'])->first();
 
             $validateEmail->existUserWithEmail($user);
             $validateEmail->isNotSuperAdmin($user['isAdmin']);
 
-            $token = uniqid();
-            $userName =  $user['userFirstName'] . " " . $user['userLastName'];
+            $token    = uniqid();
+            $userName = $user['userFirstName'] . ' ' . $user['userLastName'];
 
-            $isSend = EmailSender::sendEmail("Kinub", 'kinub@gmail.com', $data['email'], 'Restablecer Contraseña', 'templates/emails/passwordReset',  ['userName' =>  $userName, 'token' => $token] );
+            $isSend = EmailSender::sendEmail('Kinub', 'kinub@gmail.com', $data['email'], 'Restablecer Contraseña', 'templates/emails/passwordReset', ['userName' => $userName, 'token' => $token]);
 
-            if (!$isSend) throw new Exception('Algo ha salido mal, por favor recargue la página e intente nuevamente');
+            if (! $isSend) {
+                throw new Exception('Algo ha salido mal, por favor recargue la página e intente nuevamente');
+            }
 
             $response = [
-                'title' => "Restablezca su contraseña",
+                'title'   => 'Restablezca su contraseña',
                 'message' => 'Verifique su bandeja de entrada para poder restablecer su contraseña.',
-                'type' => 'success',
+                'type'    => 'success',
             ];
 
             $userModel->update($user['userId'], ['userToken' => $token]);
-        } catch (\Throwable $th) {
+        } catch (Throwable $th) {
             $errors = $validateEmail->getErrors();
 
-            if (!isset($errors['email'])) {
+            if (! isset($errors['email'])) {
                 $response = [
-                    'title' => "Oops",
+                    'title'   => 'Oops',
                     'message' => $th->getMessage(),
-                    'type' => 'danger',
+                    'type'    => 'danger',
                 ];
             } else {
-                return redirect()->back()->with("errors", $errors);
+                return redirect()->back()->with('errors', $errors);
             }
         }
 
-        return redirect()->back()->with("response", $response);
+        return redirect()->back()->with('response', $response);
     }
 }

--- a/app/Utils/EmailSender.php
+++ b/app/Utils/EmailSender.php
@@ -1,21 +1,35 @@
 <?php
+
 namespace App\Utils;
 
-use App\Models\EmailModel;
-
-class EmailSender{
-
+class EmailSender
+{
     public static function sendEmail($senderName, $senderEmail, $recipientEmail, $subject, $view, $formData): bool
     {
-
         $email = \Config\Services::email();
         $email->setFrom($senderEmail, $senderName)
             ->setTo($recipientEmail)
             ->setSubject($subject)
             ->setMessage(view($view, [
-                    "formData" => $formData
+                'formData' => $formData,
             ]));
 
         return $email->send();
+    }
+
+    public static function getEmailBody($formData, $viewEmail): string
+    {
+        $emailHTML = view($viewEmail, [
+            'formData' => $formData,
+        ]);
+
+        $emailBody = '';
+        if (preg_match('/<body>(.*?)<\/body>/is', $emailHTML, $matches)) {
+            $emailBody = $matches[1];
+
+            $emailBody = preg_replace('/\s+/', '', $emailBody);
+        }
+
+        return $emailBody;
     }
 }

--- a/app/Utils/EmailSender.php
+++ b/app/Utils/EmailSender.php
@@ -27,7 +27,7 @@ class EmailSender
         if (preg_match('/<body>(.*?)<\/body>/is', $emailHTML, $matches)) {
             $emailBody = $matches[1];
 
-            $emailBody = preg_replace('/\s+/', '', $emailBody);
+            $emailBody = trim(preg_replace('/\s+/', ' ', $emailBody));
         }
 
         return $emailBody;

--- a/lint-staged.config.js
+++ b/lint-staged.config.js
@@ -2,5 +2,5 @@ module.exports = {
   '*.{ts,js}': ['prettier --write', 'eslint --fix'],
   '*.{html,md,xml,svg,less,postcss,markdown,yml,yaml,json}': ['prettier --write'],
   '*.{css,scss,less}': ['prettier --write', 'stylelint --fix'],
-  '*.php': ['vendor/bin/php-cs-fixer fix'],
+  '*.php': ['vendor/bin/php-cs-fixer fix --config=.php-cs-fixer.dist.php'],
 };


### PR DESCRIPTION
[![KIN-279](https://badgen.net/badge/JIRA/KIN-279/blue)](https://loopcrack.atlassian.net/browse/KIN-279) ![Medium](https://badgen.net/badge/PR%20Size/Medium/yellow) [<img width="16" alt="Powered by Pull Request Badge" src="https://user-images.githubusercontent.com/1393946/111216524-d2bb8e00-85d4-11eb-821b-ed4c00989c02.png">](https://pullrequestbadge.com/?utm_medium=github&utm_source=loopcrack-org&utm_campaign=badge_info)<!-- PR-BADGE: PLEASE DO NOT REMOVE THIS COMMENT -->

the logic was changed so that the html body of the email is now stored and php-cs-fixer when it compiled my php files it found two configuration files and generated an error, so I added a flag so that it finds the project configuration

## Summary

### Problem

We need to store the email html in the database.

### Solution

Change the email database storage logic to store the html content of the email in the database. 

## Acceptance Criteria

### Requirements checklist

- [x] It must store the email html content on the database.

### Testing
It is necessary to have a mailtrap account created and replace the .env values with your account credentials.
**Note**: In the mailTpye put html

[![imagen-2023-10-21-110042390.png](https://i.postimg.cc/rFTMT3Y7/imagen-2023-10-21-110042390.png)](https://postimg.cc/XXsTcHWg)

[![imagen-2023-10-21-110330174.png](https://i.postimg.cc/vHKhfwFN/imagen-2023-10-21-110330174.png)](https://postimg.cc/Mvy1J4G7)

- [x] Check that the html is saved in the database

[KIN-279]: https://loopcrack.atlassian.net/browse/KIN-279?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ