### PR TITLE
KIN-299 File chunks implementation

### DIFF
--- a/app/Config/Routes.php
+++ b/app/Config/Routes.php
@@ -129,6 +129,7 @@ if (is_file(APPPATH . 'Config/' . ENVIRONMENT . '/Routes.php')) {
 function generateFileApiRoutesByController(RouteCollection $routes, string $controller)
 {
     $routes->post('process', [$controller, 'processTemporalFile']);
+    $routes->patch('process', [$controller, 'processTemporalFileByChunks']);
     $routes->get('restore', [$controller, 'restoreTemporalFile']);
     $routes->get('load', [$controller, 'getFileFromServer']);
     $routes->delete('delete', [$controller, 'deleteTemporalFile']);

--- a/app/Controllers/CtrlApiFiles.php
+++ b/app/Controllers/CtrlApiFiles.php
@@ -83,6 +83,26 @@ class CtrlApiFiles extends BaseController
         }
     }
 
+    public function processTemporalFileByChunks()
+    {
+        try {
+            $key        = $this->request->getGet('patch');
+            $fileName   = $this->request->header('Upload-Name')->getValue();
+            $fileLength = $this->request->header('Upload-Length')->getValue();
+            $fileData   = $this->request->getBody();
+            $offset     = $this->request->header('Upload-Offset')->getValue();
+
+            $folder  = FILES_TEMP_DIRECTORY . $key;
+            $fileTmp = "{$folder}/{$fileName}";
+
+            $temporalFileLength = FileManager::mergeChunckFiles($fileTmp, $fileData, $offset);
+
+            return $this->response->setStatusCode(204);
+        } catch (Throwable $th) {
+            return $this->response->setStatusCode(500, json_encode('Ha ocurrido un error mientras se cargaba el archivo'));
+        }
+    }
+
     /**
      * Delete a file
      *

--- a/app/Controllers/CtrlApiFiles.php
+++ b/app/Controllers/CtrlApiFiles.php
@@ -3,6 +3,7 @@
 namespace App\Controllers;
 
 use App\Utils\FileManager;
+use CodeIgniter\HTTP\Response;
 use Throwable;
 
 class CtrlApiFiles extends BaseController
@@ -23,9 +24,9 @@ class CtrlApiFiles extends BaseController
             // here you get the file route on database with the fileKey;
             $fileRoute = FILES_UPLOAD_DIRECTORY . "/{$fileKey}/foto.png"; // example
 
-            return $this->response->setStatusCode(200)->download($fileRoute['fileRoute'], null, true);
+            return $this->response->setStatusCode(Response::HTTP_OK)->download($fileRoute['fileRoute'], null, true);
         } catch (Throwable $th) {
-            return $this->response->setStatusCode(404, 'No se ha podido encontrar el archivo');
+            return $this->response->setStatusCode(Response::HTTP_NOT_FOUND, 'No se ha podido encontrar el archivo');
         }
     }
 
@@ -45,9 +46,9 @@ class CtrlApiFiles extends BaseController
             $folder = FILES_TEMP_DIRECTORY . $key;
             $file   = FileManager::getFileFromFolder($folder)[0];
 
-            return $this->response->setStatusCode(200)->download($file, null, true);
+            return $this->response->setStatusCode(Response::HTTP_OK)->download($file, null, true);
         } catch (Throwable $th) {
-            return $this->response->setStatusCode(404, 'No se ha podido encontrar el archivo');
+            return $this->response->setStatusCode(Response::HTTP_NOT_FOUND, 'No se ha podido encontrar el archivo');
         }
     }
 
@@ -77,9 +78,9 @@ class CtrlApiFiles extends BaseController
                 FileManager::moveClientFileToServer($file, $folder);
             }
 
-            return $this->response->setStatusCode(201)->setJSON(['key' => $key]);
+            return $this->response->setStatusCode(Response::HTTP_OK)->setJSON(['key' => $key]);
         } catch (Throwable $th) {
-            return $this->response->setStatusCode(500, json_encode('Ha ocurrido un error mientras se cargaba el archivo'));
+            return $this->response->setStatusCode(Response::HTTP_INTERNAL_SERVER_ERROR, json_encode('Ha ocurrido un error mientras se cargaba el archivo'));
         }
     }
 
@@ -97,9 +98,9 @@ class CtrlApiFiles extends BaseController
 
             $temporalFileLength = FileManager::mergeChunckFiles($fileTmp, $fileData, $offset);
 
-            return $this->response->setStatusCode(204);
+            return $this->response->setStatusCode(Response::HTTP_OK);
         } catch (Throwable $th) {
-            return $this->response->setStatusCode(500, json_encode('Ha ocurrido un error mientras se cargaba el archivo'));
+            return $this->response->setStatusCode(Response::HTTP_INTERNAL_SERVER_ERROR, json_encode('Ha ocurrido un error mientras se cargaba el archivo'));
         }
     }
 
@@ -119,9 +120,9 @@ class CtrlApiFiles extends BaseController
             $folder = FILES_TEMP_DIRECTORY . $key;
             FileManager::deleteFolderWithContent($folder);
 
-            return $this->response->setStatusCode(201);
+            return $this->response->setStatusCode(Response::HTTP_OK);
         } catch (Throwable $th) {
-            return $this->response->setStatusCode(500, $th->getMessage());
+            return $this->response->setStatusCode(Response::HTTP_INTERNAL_SERVER_ERROR, $th->getMessage());
         }
     }
 }

--- a/app/Controllers/CtrlTestFiles.php
+++ b/app/Controllers/CtrlTestFiles.php
@@ -15,6 +15,8 @@ class CtrlTestFiles extends CtrlApiFiles
             'acceptedFileTypes'                  => ['image/jpg', 'image/png', 'image/jpeg'],
             'fileValidateTypeLabelExpectedTypes' => 'Selecciona sólo archivos con la extensión .jpg, .jpeg o .png',
             'labelFileTypeNotAllowed'            => 'Archivo no válido',
+            'chunkUploads'                       => true,
+            'chunkSize'                          => 100000,
             'allowMultiple'                      => true,
             'maxFiles'                           => 3,
             'minFiles'                           => 2,

--- a/app/Utils/FileManager.php
+++ b/app/Utils/FileManager.php
@@ -124,6 +124,33 @@ class FileManager
     }
 
     /**
+     * Merge data into a file
+     *
+     * @param string $filePath   the path to the file
+     * @param string $fileData   the binary data
+     * @param string $fileOffset The position in bytes, from where the data will be added
+     *
+     * @throws Exception If an error occurs while adding the data to the file
+     */
+    public static function mergeChunckFiles(string $filePath, string $fileData, string $fileOffset)
+    {
+        try {
+            if (! file_exists($filePath)) {
+                file_put_contents($filePath, '');
+            }
+
+            $fileOpen = fopen($filePath, 'r+b');
+            fseek($fileOpen, $fileOffset);
+            fwrite($fileOpen, $fileData);
+            fclose($fileOpen);
+
+            return filesize($filePath);
+        } catch (Throwable $th) {
+            throw new Exception('Ha ocurrido un error al procesar el archivo por partes');
+        }
+    }
+
+    /**
      * Delete a folder and its content.
      *
      * @param string $folderPath Path of the folder to delete.


### PR DESCRIPTION
[![KIN-299](https://badgen.net/badge/JIRA/KIN-299/blue)](https://loopcrack.atlassian.net/browse/KIN-299) ![Small](https://badgen.net/badge/PR%20Size/Small/green) [<img width="16" alt="Powered by Pull Request Badge" src="https://user-images.githubusercontent.com/1393946/111216524-d2bb8e00-85d4-11eb-821b-ed4c00989c02.png">](https://pullrequestbadge.com/?utm_medium=github&utm_source=loopcrack-org&utm_campaign=badge_info)<!-- PR-BADGE: PLEASE DO NOT REMOVE THIS COMMENT -->

## Summary

### Problem

It is needed a way to deal with big files uploaded by the users.

### Solution

Implement chunk files for bigger files uploaded by the users

## Acceptance Criteria

### Requirements checklist

- [x] The routes must have a route where the filepond script can be able to send patch request
- [x] The CtrlApiFiles must manage the patch request where can be able to manage big files in chunks.
- [x] The FileManager class must have a method that merge all fragments of a file sended in chunks.

### Testing

- [x] Remember install all dependencies with `npm install` and run the project with `npm run dev:admin`
- [x] change `.env` variable  `CI_ENVIRONMENT = development` to `CI_ENVIRONMENT = production`
- [x] Into the filepond configuration setted from the class CtrlTestFiles you can see the values `chunkUploads = true` and `chunkSize = 100000` that means that now filepond can try to process files bigger than the `chunkSize` setted in bytes. 
- [x] Try to upload a file you know is bigger than `100000 bytes`, then you can see how the file is uploading. 

## Resources

[Reference Filepond Chunks](https://pqina.nl/filepond/docs/api/server/#process-chunks) 

## Demo

https://github.com/loopcrack-org/Kinub/assets/70463645/cf1eadb5-6d8b-48b7-b348-7eab09868c4f

[KIN-299]: https://loopcrack.atlassian.net/browse/KIN-299?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ