### PR TITLE
KIN-300 File Validations

### DIFF
--- a/app/Config/Validation.php
+++ b/app/Config/Validation.php
@@ -2,9 +2,9 @@
 
 namespace Config;
 
+use App\Libraries\fileValidation\FileRules;
 use CodeIgniter\Config\BaseConfig;
 use CodeIgniter\Validation\StrictRules\CreditCardRules;
-use CodeIgniter\Validation\StrictRules\FileRules;
 use CodeIgniter\Validation\StrictRules\FormatRules;
 use CodeIgniter\Validation\StrictRules\Rules;
 

--- a/app/Controllers/CtrlApiFiles.php
+++ b/app/Controllers/CtrlApiFiles.php
@@ -90,13 +90,11 @@ class CtrlApiFiles extends BaseController
                         $inputName => $configValidation['messages'],
                     ]
                 );
-                $validation->run([$inputName => $file]);
-                if (! $validation->hasError($inputName)) {
+                if (! $validation->run([$inputName => $file])) {
                     $error = $validation->getError($inputName);
 
                     throw new FileValidationException($error);
                 }
-
                 FileManager::moveClientFileToServer($file, $folder);
             }
 

--- a/app/Controllers/CtrlApiFiles.php
+++ b/app/Controllers/CtrlApiFiles.php
@@ -91,7 +91,7 @@ class CtrlApiFiles extends BaseController
                     ]
                 );
                 $validation->run([$inputName => $file]);
-                if ($validation->hasError($inputName)) {
+                if (! $validation->hasError($inputName)) {
                     $error = $validation->getError($inputName);
 
                     throw new FileValidationException($error);

--- a/app/Controllers/CtrlApiFiles.php
+++ b/app/Controllers/CtrlApiFiles.php
@@ -2,12 +2,17 @@
 
 namespace App\Controllers;
 
+use App\Exceptions\FileValidationException;
 use App\Utils\FileManager;
+use CodeIgniter\Files\File;
 use CodeIgniter\HTTP\Response;
+use Config\Services;
 use Throwable;
 
 class CtrlApiFiles extends BaseController
 {
+    protected $validationConfig;
+
     /**
      * Get a file
      *
@@ -75,10 +80,29 @@ class CtrlApiFiles extends BaseController
             FileManager::createFolder($folder);
 
             if ($file) {
+                $configValidation = $this->validationConfig[$inputName];
+                $validation       = Services::validation();
+                $validation->setRules(
+                    [
+                        $inputName => $configValidation['rules'],
+                    ],
+                    [
+                        $inputName => $configValidation['messages'],
+                    ]
+                );
+                $validation->run([$inputName => $file]);
+                if ($validation->hasError($inputName)) {
+                    $error = $validation->getError($inputName);
+
+                    throw new FileValidationException($error);
+                }
+
                 FileManager::moveClientFileToServer($file, $folder);
             }
 
             return $this->response->setStatusCode(Response::HTTP_OK)->setJSON(['key' => $key]);
+        } catch (FileValidationException $th) {
+            return $this->response->setStatusCode(Response::HTTP_INTERNAL_SERVER_ERROR, json_encode($th->getMessage()));
         } catch (Throwable $th) {
             return $this->response->setStatusCode(Response::HTTP_INTERNAL_SERVER_ERROR, json_encode('Ha ocurrido un error mientras se cargaba el archivo'));
         }
@@ -98,7 +122,29 @@ class CtrlApiFiles extends BaseController
 
             $temporalFileLength = FileManager::mergeChunckFiles($fileTmp, $fileData, $offset);
 
+            if ((string) $temporalFileLength === $fileLength) {
+                $file             = new File($fileTmp);
+                $inputName        = $this->request->header('Input')->getValue();
+                $configValidation = $this->validationConfig[$inputName];
+                $validation       = Services::validation();
+                $validation->setRules(
+                    [
+                        $inputName => $configValidation['rules'],
+                    ],
+                    [
+                        $inputName => $configValidation['messages'],
+                    ]
+                );
+                if (! $validation->run([$inputName => $file])) {
+                    $error = $validation->getError($inputName);
+
+                    throw new FileValidationException($error);
+                }
+            }
+
             return $this->response->setStatusCode(Response::HTTP_OK);
+        } catch (FileValidationException $th) {
+            return $this->response->setStatusCode(Response::HTTP_INTERNAL_SERVER_ERROR, json_encode($th->getMessage()));
         } catch (Throwable $th) {
             return $this->response->setStatusCode(Response::HTTP_INTERNAL_SERVER_ERROR, json_encode('Ha ocurrido un error mientras se cargaba el archivo'));
         }

--- a/app/Controllers/CtrlTestFiles.php
+++ b/app/Controllers/CtrlTestFiles.php
@@ -6,38 +6,54 @@ class CtrlTestFiles extends CtrlApiFiles
 {
     /**
      * This variable container examples for filepond configuration
-     * for image and viddeo files
+     * for image
      */
     protected $filepondConfig = [
         'baseUrl' => '/admin/testFiles',
         'image'   => [
-            'name'                               => 'image',
-            'acceptedFileTypes'                  => ['image/jpg', 'image/png', 'image/jpeg'],
+            'name' => 'image',
+            // 'acceptedFileTypes'                  => ['image/jpg', 'image/png', 'image/jpeg'],
             'fileValidateTypeLabelExpectedTypes' => 'Selecciona sólo archivos con la extensión .jpg, .jpeg o .png',
             'labelFileTypeNotAllowed'            => 'Archivo no válido',
             'chunkUploads'                       => true,
             'chunkSize'                          => 100000,
             'allowMultiple'                      => true,
-            'maxFiles'                           => 3,
-            'minFiles'                           => 2,
-            'imagePreviewHeight'                 => 170,
-            'imageCropAspectRatio'               => '1:1',
-            'imageResizeTargetWidth'             => 200,
-            'imageResizeTargetHeight'            => 200,
-            'allowFileSizeValidation'            => true,
-            'maxFileSize'                        => '5MB',
-            'minFileSize'                        => '100KB',
-            'labelIdle'                          => 'Arrastra y suelta tus archivos o <span class="filepond--label-action"> Selecciona </span>',
-            'labelFileLoading'                   => 'Cargando',
-            'labelFileProcessing'                => 'Procesando',
-            'labelFileProcessingComplete'        => 'Carga completada',
-            'labelTapToUndo'                     => 'toque para deshacer',
-            'labelTapToCancel'                   => 'toque para cancelar',
-            'labelFileWaitingForSize'            => 'Esperando tamaño',
-            'labelMaxFileSizeExceeded'           => 'El archivo es demasiado grande.',
-            'labelMaxFileSize'                   => 'El tamaño máximo permitido es de {filesize}',
-            'labelMinFileSizeExceeded'           => 'El archivo es demasiado pequeño',
-            'labelMinFileSize'                   => 'El tamaño mínimo permitido es de {filesize}',
+            // 'maxFiles'                           => 3,
+            // 'minFiles'                           => 2,
+            'imagePreviewHeight'      => 170,
+            'imageCropAspectRatio'    => '1:1',
+            'imageResizeTargetWidth'  => 200,
+            'imageResizeTargetHeight' => 200,
+            'allowFileSizeValidation' => true,
+            // 'maxFileSize'                        => '5MB',
+            // 'minFileSize'                        => '100KB',
+            'labelIdle'                   => 'Arrastra y suelta tus archivos o <span class="filepond--label-action"> Selecciona </span>',
+            'labelFileLoading'            => 'Cargando',
+            'labelFileProcessing'         => 'Procesando',
+            'labelFileProcessingComplete' => 'Carga completada',
+            'labelTapToUndo'              => 'toque para deshacer',
+            'labelTapToCancel'            => 'toque para cancelar',
+            'labelFileWaitingForSize'     => 'Esperando tamaño',
+            'labelMaxFileSizeExceeded'    => 'El archivo es demasiado grande.',
+            'labelMaxFileSize'            => 'El tamaño máximo permitido es de {filesize}',
+            'labelMinFileSizeExceeded'    => 'El archivo es demasiado pequeño',
+            'labelMinFileSize'            => 'El tamaño mínimo permitido es de {filesize}',
+        ],
+    ];
+
+    /**
+     * configuration for validation from server through the api
+     */
+    protected $validationConfig = [
+        'image' => [
+            'rules'    => 'maxSize[200,kb]|minSize[1,kb]|maxDims[3000,3000]|mimeIn[image/png,image/jpeg,image/jpg]|extIn[png,jpeg,jpg]',
+            'messages' => [
+                'maxSize' => 'La imagen debe ser menor a 100 kilobytes',
+                'minSize' => 'La imagen debe ser mayor a 1 kilobytes',
+                'maxDims' => 'Las dimensiones máximas de imagen son de 100px por 100px',
+                'mimeIn'  => 'Tipo de archivo inválido, selecciona image/png,image/jpeg,image/jpg',
+                'extIn'   => 'Extensión de archivo inválido, selecciona .png, .jpeg o .jpg',
+            ],
         ],
     ];
 

--- a/app/Controllers/CtrlTestFiles.php
+++ b/app/Controllers/CtrlTestFiles.php
@@ -46,7 +46,7 @@ class CtrlTestFiles extends CtrlApiFiles
      */
     protected $validationConfig = [
         'image' => [
-            'rules'    => 'maxSize[200,kb]|minSize[1,kb]|maxDims[3000,3000]|mimeIn[image/png,image/jpeg,image/jpg]|extIn[png,jpeg,jpg]',
+            'rules'    => 'maxSize[200,kb]|minSize[1,kb]|maxDims[3000,3000]|mimeIn[image/png,image/jpeg,image/jpg]',
             'messages' => [
                 'maxSize' => 'La imagen debe ser menor a 100 kilobytes',
                 'minSize' => 'La imagen debe ser mayor a 1 kilobytes',

--- a/app/Controllers/CtrlTestFiles.php
+++ b/app/Controllers/CtrlTestFiles.php
@@ -46,7 +46,7 @@ class CtrlTestFiles extends CtrlApiFiles
      */
     protected $validationConfig = [
         'image' => [
-            'rules'    => 'maxSize[200,kb]|minSize[1,kb]|maxDims[3000,3000]|mimeIn[image/png,image/jpeg,image/jpg]',
+            'rules'    => 'maxSize[200,kb]|minSize[1,b]|mimeIn[image/png,image/jpeg,image/jpg]|maxDims[3000,3000]',
             'messages' => [
                 'maxSize' => 'La imagen debe ser menor a 100 kilobytes',
                 'minSize' => 'La imagen debe ser mayor a 1 kilobytes',

--- a/app/Exceptions/FileValidationException.php
+++ b/app/Exceptions/FileValidationException.php
@@ -1,0 +1,13 @@
+<?php
+
+namespace App\Exceptions;
+
+use Exception;
+
+class FileValidationException extends Exception
+{
+    public function getFileValidationError()
+    {
+        return $this->getMessage();
+    }
+}

--- a/app/Libraries/fileValidation/FileRules.php
+++ b/app/Libraries/fileValidation/FileRules.php
@@ -1,0 +1,162 @@
+<?php
+
+namespace App\Libraries\fileValidation;
+
+use CodeIgniter\Files\File;
+use Config\Mimes;
+
+class FileRules
+{
+    /**
+     * Verifies if the file's size in given unit is no larger than the parameter.
+     *
+     * @param File  $file   the instance of file
+     * @param mixed $params params passed through validation rules
+     */
+    public function maxSize(File $file, $params)
+    {
+        if ($file === null) {
+            return false;
+        }
+
+        $params = explode(',', $params);
+
+        $size = $file->getSizeByUnit(strtolower($params[1]));
+
+        $accepted = $params[0];
+
+        return $accepted > $size;
+    }
+
+    /**
+     * Verifies if the file's size in given unit is larger than the parameter.
+     *
+     * @param File  $file   the instance of file
+     * @param mixed $params params passed through validation rules
+     */
+    public function minSize(File $file, $params)
+    {
+        if ($file === null) {
+            return false;
+        }
+
+        $params = explode(',', $params);
+
+        $size = $file->getSizeByUnit(strtolower($params[1]));
+
+        $accepted = $params[0];
+
+        return $accepted < $size;
+    }
+
+    /**
+     * Uses the mime config file to determine if a file is considered an "image",
+     * which for our purposes basically means that it's a raster image or svg.
+     *
+     * @param File  $file   the instance of file
+     * @param mixed $params params passed through validation rules
+     */
+    public function isImage(File $file, $params)
+    {
+        $params = explode(',', $params);
+
+        if ($file === null) {
+            return false;
+        }
+
+        // We know that our mimes list always has the first mime
+        // start with `image` even when then are multiple accepted types.
+        $type = Mimes::guessTypeFromExtension($file->getExtension()) ?? '';
+
+        return ! (mb_strpos($type, 'image') !== 0);
+    }
+
+    /**
+     * Checks to see if an uploaded file's mime type matches one in the parameter.
+     *
+     * @param File  $file   the instance of file
+     * @param mixed $params params passed through validation rules
+     */
+    public function mimeIn(File $file, $params)
+    {
+        $params = explode(',', $params);
+
+        if ($file === null) {
+            return false;
+        }
+
+        return ! (! in_array($file->getMimeType(), $params, true));
+    }
+
+    /**
+     * Checks to see if an uploaded file's extension matches one in the parameter.
+     *
+     * @param File  $file   the instance of file
+     * @param mixed $params params passed through validation rules
+     */
+    public function extIn(File $file, $params)
+    {
+        $params = explode(',', $params);
+
+        if ($file === null) {
+            return false;
+        }
+
+        return ! (! in_array($file->guessExtension(), $params, true));
+    }
+
+    /**
+     * Checks an uploaded file to verify that the dimensions are within
+     * a specified allowable dimension.
+     *
+     * @param File  $file   the instance of file
+     * @param mixed $params params passed through validation rules
+     */
+    public function maxDims(File $file, $params)
+    {
+        $params = explode(',', $params);
+
+        if ($file === null) {
+            return false;
+        }
+
+        // Get Parameter sizes
+        $allowedWidth  = $params[0] ?? 0;
+        $allowedHeight = $params[1] ?? 0;
+
+        // Get uploaded image size
+        $info       = getimagesize($file->getRealPath());
+        $fileWidth  = $info[0];
+        $fileHeight = $info[1];
+
+        return ! ($fileWidth > $allowedWidth || $fileHeight > $allowedHeight);
+    }
+
+    /**
+     * Check if the array has the maximum items according to the max number passed on param
+     *
+     * @param File  $file   the instance of file
+     * @param mixed $params params passed through validation rules
+     */
+    public function maxFiles(array $files, $params)
+    {
+        $maxFiles = $params;
+        $numFiles = count($files);
+
+        return ! ($numFiles > $maxFiles);
+    }
+
+    /**
+     * Check if the array has the minimum items according to the min number passed on param
+     *
+     * @param File  $file   the instance of file
+     * @param mixed $params params passed through validation rules
+     */
+    public function minFiles(array $files, $params)
+    {
+        $minFiles = $params;
+        $numFiles = count($files);
+
+        return ! ($numFiles < $minFiles || $files[0] === '');
+    }
+}

--- a/app/Libraries/fileValidation/FileRules.php
+++ b/app/Libraries/fileValidation/FileRules.php
@@ -95,7 +95,7 @@ class FileRules
     /**
      * Check if the array has the maximum items according to the max number passed on param
      *
-     * @param File  $file   the instance of file
+     * @param array $files  the files to validate
      * @param mixed $params params passed through validation rules
      */
     public function maxFiles(array $files, $params)
@@ -109,7 +109,7 @@ class FileRules
     /**
      * Check if the array has the minimum items according to the min number passed on param
      *
-     * @param File  $file   the instance of file
+     * @param array $files  the files to validate
      * @param mixed $params params passed through validation rules
      */
     public function minFiles(array $files, $params)

--- a/app/Libraries/fileValidation/FileRules.php
+++ b/app/Libraries/fileValidation/FileRules.php
@@ -3,7 +3,6 @@
 namespace App\Libraries\fileValidation;
 
 use CodeIgniter\Files\File;
-use Config\Mimes;
 
 class FileRules
 {
@@ -50,28 +49,6 @@ class FileRules
     }
 
     /**
-     * Uses the mime config file to determine if a file is considered an "image",
-     * which for our purposes basically means that it's a raster image or svg.
-     *
-     * @param File  $file   the instance of file
-     * @param mixed $params params passed through validation rules
-     */
-    public function isImage(File $file, $params)
-    {
-        $params = explode(',', $params);
-
-        if ($file === null) {
-            return false;
-        }
-
-        // We know that our mimes list always has the first mime
-        // start with `image` even when then are multiple accepted types.
-        $type = Mimes::guessTypeFromExtension($file->getExtension()) ?? '';
-
-        return ! (mb_strpos($type, 'image') !== 0);
-    }
-
-    /**
      * Checks to see if an uploaded file's mime type matches one in the parameter.
      *
      * @param File  $file   the instance of file
@@ -86,23 +63,6 @@ class FileRules
         }
 
         return ! (! in_array($file->getMimeType(), $params, true));
-    }
-
-    /**
-     * Checks to see if an uploaded file's extension matches one in the parameter.
-     *
-     * @param File  $file   the instance of file
-     * @param mixed $params params passed through validation rules
-     */
-    public function extIn(File $file, $params)
-    {
-        $params = explode(',', $params);
-
-        if ($file === null) {
-            return false;
-        }
-
-        return ! (! in_array($file->guessExtension(), $params, true));
     }
 
     /**


### PR DESCRIPTION
[![KIN-300](https://badgen.net/badge/JIRA/KIN-300/blue)](https://loopcrack.atlassian.net/browse/KIN-300) ![Medium](https://badgen.net/badge/PR%20Size/Medium/yellow) [<img width="16" alt="Powered by Pull Request Badge" src="https://user-images.githubusercontent.com/1393946/111216524-d2bb8e00-85d4-11eb-821b-ed4c00989c02.png">](https://pullrequestbadge.com/?utm_medium=github&utm_source=loopcrack-org&utm_campaign=badge_info)<!-- PR-BADGE: PLEASE DO NOT REMOVE THIS COMMENT -->

## Summary

### Problem

It is needed to validate the files given by the users through the CtrlApiFile

### Solution

Define and integrate validations rules on the files given by the users

## Acceptance Criteria

### Requirements checklist

- [x] There must be a File validations object
- [x] The file validation must be integrated on the files API
- [x] Must validate only one file at once according the way the CtrlApiFiles receives the files
- [x] There is a class with set of file validations rules defined and used into the validation services provided by codeigniter.

### Testing

Recommended testing by following:

- [x] Rememeber do `npm install` and `npm run dev:admin` and run the project on production mode
- [x] Go to the controller CtrlTestFiles, and you can see that there is some properties on the filepondConfiguration that are commented, that is in order you can test only the validation from server and filepond doesn´t interfere with the validation
- [x] put your screens like following:
![image](https://github.com/loopcrack-org/Kinub/assets/70463645/e2ec3048-ac8e-4d1a-8ea1-39a66b526029)
- [x] Now you can use the following image to upload on filepond box and test this pull request:
- specifications:
   - size: 158 Kb
   - dims: 1920 x 1080
   - ext: .png
   - mime type: image/png
![3](https://github.com/loopcrack-org/Kinub/assets/70463645/b75939b7-2a62-4189-a73c-f1d40918252f)

- [x] With the specification provided you know how to modify the validation rules on CtrlTestFiles, to prove every rule on validation.
- [x] For example, if you want to prove the maxSize rule, you can set `maxSize[100,kb]` in order the validation fails, because of the file size is 158 kb. you can set `maxSize[200,kb]` in order the validation pass.
- [x] you can do the above with the other validation rules.

## Resources
## Demo

[KIN-300]: https://loopcrack.atlassian.net/browse/KIN-300?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ