### PR TITLE
KIN-353 Added Security Headers to Website

### DIFF
--- a/htaccess.production
+++ b/htaccess.production
@@ -24,6 +24,27 @@ Options -Indexes
 	ErrorDocument 404 public/index.php
 </IfModule>
 
+# Add headers for security
+<IfModule mod_headers.c>
+   # Strict-Transport-Security
+   Header always set Strict-Transport-Security "max-age=31536000; includeSubDomains"
+
+   # Content-Security-Policy
+   Header always set Content-Security-Policy "upgrade-insecure-requests;"
+
+   # X-Frame-Options
+   Header always set X-Frame-Options "SAMEORIGIN"
+
+   # X-Content-Type-Options
+   Header always set X-Content-Type-Options "nosniff"
+
+   # Referrer-Policy
+   Header always set Referrer-Policy "strict-origin-when-cross-origin"
+
+   # Permissions-Policy
+   Header always set Permissions-Policy "camera=(), microphone=(), geolocation=()"
+</IfModule>
+
 # Disable server signature start
 	ServerSignature Off
 # Disable server signature end


### PR DESCRIPTION
[![KIN-353](https://badgen.net/badge/JIRA/KIN-353/blue)](https://loopcrack.atlassian.net/browse/KIN-353) ![Small](https://badgen.net/badge/PR%20Size/Small/green) [<img width="16" alt="Powered by Pull Request Badge" src="https://user-images.githubusercontent.com/1393946/111216524-d2bb8e00-85d4-11eb-821b-ed4c00989c02.png">](https://pullrequestbadge.com/?utm_medium=github&utm_source=loopcrack-org&utm_campaign=badge_info)<!-- PR-BADGE: PLEASE DO NOT REMOVE THIS COMMENT -->

## Summary

### Problem

Security headers were missing from the website which made the website vulnerable

### Solution

Added Security Headers to the Website

## Acceptance Criteria

### Requirements checklist

- [x] The security headers should be added in production htaccess

### Testing

These tests can be done with kinub.loopcrack.com when the changes are ready to verify the headers

- [x] Use the browser inspection tool of your browser and on the network tab you can check the requests headers to check that the new ones are set
- [x] Use a tool to scan for security headers for example [Security Headers](https://securityheaders.com/?q=https%3A%2F%2Fkinub.loopcrack.com%2F&followRedirects=on)

## Resources

- [Security Headers Tool](https://securityheaders.com/?q=https%3A%2F%2Fkinub.loopcrack.com%2F&followRedirects=on)

## Demo

![image](https://github.com/loopcrack-org/Kinub/assets/38699927/baf4f861-ef2d-4ac4-81cf-85e8379c94d5)

[KIN-353]: https://loopcrack.atlassian.net/browse/KIN-353?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ