### PR TITLE
KIN-349 integrate with admin panel - certificates page 

### DIFF
--- a/app/Controllers/CtrlPublicPages.php
+++ b/app/Controllers/CtrlPublicPages.php
@@ -2,6 +2,8 @@
 
 namespace App\Controllers;
 
+use App\Models\CertificateModel;
+
 class CtrlPublicPages extends BaseController
 {
     public function index(): string
@@ -43,9 +45,11 @@ class CtrlPublicPages extends BaseController
 
     public function viewCertificates(): string
     {
-        $data = [
+        $certificates = (new CertificateModel())->getAllCertificateWithFiles();
+        $data         = [
             'metaTitle'       => 'Certificados',
             'metaDescription' => 'Conoce los Certificados que acreditan la experiencia y excelencia de Kinub',
+            'certificates'    => $certificates,
         ];
 
         return view('public/certificates', $data);

--- a/app/Models/CertificateModel.php
+++ b/app/Models/CertificateModel.php
@@ -70,15 +70,35 @@ class CertificateModel extends Model
 
     public function getCertificate($id)
     {
-        return $this->select('certificates.certificateId, certificates.certificatefileName,
-                   preview.fileId AS previewFileId, preview.uuid AS previewUuid,
-                   certfile.fileId AS certificateFileId, certfile.uuid AS certificateUuid')->join('files as preview', 'certificates.certificatePreviewId = preview.fileId', 'left')->join('files as certfile', 'certificates.certificatefileId = certfile.fileId', 'left')->where('certificates.certificateId', $id)->first();
+        return $this->select('
+            certificates.certificateId,
+            certificates.certificatefileName,
+            preview.fileId AS previewFileId,
+            preview.uuid AS previewUuid,
+            certfile.fileId AS certificateFileId,
+            certfile.uuid AS certificateUuid')
+            ->join('files as preview', 'certificates.certificatePreviewId = preview.fileId', 'left')
+            ->join('files as certfile', 'certificates.certificatefileId = certfile.fileId', 'left')
+            ->where('certificates.certificateId', $id)->first();
     }
 
     public function getAllCertificateWithFiles()
     {
-        return $this->select('certificates.certificateId, certificates.certificatefileName,
-                   preview.fileId AS previewFileId, preview.fileRoute AS previewFileRoute, preview.uuid AS previewUuid, preview.fileName AS previewFileName, preview.fileDirectoryRoute AS previewFileDirectoryRoute,
-                   certfile.fileId AS certificateFileId, certfile.fileRoute AS certificateFileRoute, certfile.uuid AS certificateUuid, certfile.fileName AS certificateFileName, certfile.fileDirectoryRoute AS certificateFileDirectoryRoute')->join('files as preview', 'certificates.certificatePreviewId = preview.fileId', 'left')->join('files as certfile', 'certificates.certificatefileId = certfile.fileId', 'left')->findAll();
+        return $this->select('
+            certificates.certificateId,
+            certificates.certificatefileName,
+            preview.fileId AS previewFileId,
+            preview.fileRoute AS previewFileRoute,
+            preview.uuid AS previewUuid,
+            preview.fileName AS previewFileName,
+            preview.fileDirectoryRoute AS previewFileDirectoryRoute,
+            certfile.fileId AS certificateFileId,
+            certfile.fileRoute AS certificateFileRoute,
+            certfile.uuid AS certificateUuid,
+            certfile.fileName AS certificateFileName,
+            certfile.fileDirectoryRoute AS certificateFileDirectoryRoute')
+            ->join('files as preview', 'certificates.certificatePreviewId = preview.fileId', 'left')
+            ->join('files as certfile', 'certificates.certificatefileId = certfile.fileId', 'left')
+            ->findAll();
     }
 }

--- a/app/Models/CertificateModel.php
+++ b/app/Models/CertificateModel.php
@@ -74,4 +74,11 @@ class CertificateModel extends Model
                    preview.fileId AS previewFileId, preview.uuid AS previewUuid,
                    certfile.fileId AS certificateFileId, certfile.uuid AS certificateUuid')->join('files as preview', 'certificates.certificatePreviewId = preview.fileId', 'left')->join('files as certfile', 'certificates.certificatefileId = certfile.fileId', 'left')->where('certificates.certificateId', $id)->first();
     }
+
+    public function getAllCertificateWithFiles()
+    {
+        return $this->select('certificates.certificateId, certificates.certificatefileName,
+                   preview.fileId AS previewFileId, preview.fileRoute AS previewFileRoute, preview.uuid AS previewUuid, preview.fileName AS previewFileName, preview.fileDirectoryRoute AS previewFileDirectoryRoute,
+                   certfile.fileId AS certificateFileId, certfile.fileRoute AS certificateFileRoute, certfile.uuid AS certificateUuid, certfile.fileName AS certificateFileName, certfile.fileDirectoryRoute AS certificateFileDirectoryRoute')->join('files as preview', 'certificates.certificatePreviewId = preview.fileId', 'left')->join('files as certfile', 'certificates.certificatefileId = certfile.fileId', 'left')->findAll();
+    }
 }

--- a/app/Views/public/certificates.php
+++ b/app/Views/public/certificates.php
@@ -11,86 +11,16 @@
     <h1 class="certificates__heading title--level-3">Certificados</h1>
 
     <section class="certificates__grid">
-        <a href="#" target="_blank" class="certificate kinub-card">
+        <?php foreach ($certificates as $certificate) { ?>
+        <a href="<?= $certificate['certificateFileRoute']?>" target="_blank" class="certificate kinub-card">
             <div class="certificate__image-container">
-                <img class="certificate__image " src="assets/images/pdf-example.png" alt="Certificado">
+                <img class="certificate__image " src="<?= $certificate['previewFileRoute']?>" alt="<?= $certificate['certificatefileName']?>">
             </div>
             <div class="certificate__information">
-                <p class="certificate__name">Certificado con algún nombre no tan largo</p>
+                <p class="certificate__name"><?= $certificate['certificatefileName']?></p>
             </div>
         </a>
-
-        <a href="#" target="_blank" class="certificate kinub-card">
-            <div class="certificate__image-container">
-        <img class="certificate__image " src="assets/images/pdf-example.png" alt="Certificado">
-            </div>
-            <div class="certificate__information">
-                <p class="certificate__name">Certificado con nombre un poco más largo que el otro</p>
-            </div>
-        </a>
-
-        <a href="#" target="_blank" class="certificate kinub-card">
-            <div class="certificate__image-container">
-            <img class="certificate__image " src="assets/images/pdf-horizontal-example.jpg" alt="Certificado">
-            </div>
-            <div class="certificate__information">
-                <p class="certificate__name">Certificado con algún nombre no tan largo</p>
-            </div>
-        </a>
-
-        <a href="#" target="_blank" class="certificate kinub-card">
-            <div class="certificate__image-container">
-                <img class="certificate__image " src="assets/images/pdf-example.png" alt="Certificado">
-            </div>
-            <div class="certificate__information">
-                <p class="certificate__name">Certificado con algún nombre no tan largo</p>
-            </div>
-        </a>
-
-        <a href="#" target="_blank" class="certificate kinub-card">
-            <div class="certificate__image-container">
-              <img class="certificate__image " src="assets/images/pdf-example.png" alt="Certificado">
-            </div>
-            <div class="certificate__information">
-                <p class="certificate__name">Certificado con algún nombre no tan largo</p>
-            </div>
-        </a>
-
-        <a href="#" target="_blank" class="certificate kinub-card">
-            <div class="certificate__image-container">
-                <img class="certificate__image " src="assets/images/pdf-horizontal-example.jpg" alt="Certificado">
-            </div>
-            <div class="certificate__information">
-                <p class="certificate__name">Certificado con algún nombre no tan largo</p>
-            </div>
-        </a>
-
-        <a href="#" target="_blank" class="certificate kinub-card">
-            <div class="certificate__image-container">
-                <img class="certificate__image " src="assets/images/pdf-horizontal-example.jpg" alt="Certificado">
-            </div>
-            <div class="certificate__information">
-                <p class="certificate__name">Certificado con algún nombre no tan largo</p>
-            </div>
-        </a>
-
-        <a href="#" target="_blank" class="certificate kinub-card">
-            <div class="certificate__image-container">
-                <img class="certificate__image " src="assets/images/pdf-example.png" alt="Certificado">
-            </div>
-            <div class="certificate__information">
-                <p class="certificate__name">Certificado con algún nombre no tan largo</p>
-            </div>
-        </a>
-
-        <a href="#" target="_blank" class="certificate kinub-card">
-            <div class="certificate__image-container">
-                <img class="certificate__image " src="assets/images/pdf-example.png" alt="Certificado">
-            </div>
-            <div class="certificate__information">
-                <p class="certificate__name">Certificado con algún nombre no tan largo</p>
-            </div>
-        </a>
+        <?php }?>
     </section>
 </main>
 


### PR DESCRIPTION
[![KIN-349](https://badgen.net/badge/JIRA/KIN-349/blue)](https://loopcrack.atlassian.net/browse/KIN-349) ![Small](https://badgen.net/badge/PR%20Size/Small/green) [<img width="16" alt="Powered by Pull Request Badge" src="https://user-images.githubusercontent.com/1393946/111216524-d2bb8e00-85d4-11eb-821b-ed4c00989c02.png">](https://pullrequestbadge.com/?utm_medium=github&utm_source=loopcrack-org&utm_campaign=badge_info)<!-- PR-BADGE: PLEASE DO NOT REMOVE THIS COMMENT -->

## Summary

### Problem

 It is needed to integrate the admin panel generated values with the public view.

### Solution

Integrate the certificates generated in the admin panel on the equipments page.

## Acceptance Criteria

### Requirements checklist

- [x] For each certificate record a certificate card must be displayed on the certificates page: The name of the certificate in the record
- [x] Each certificate card when clicked must redirect to a new tab with the certificate file attached.
- [ ] Each certificate card must display its preview image previously stored via the admin panel

### Testing

- [x]  Go to the next route /admin/certificados/crear and create the corresponding certificate.
- [x] Go to the certificates page and check that the previously uploaded files are reflected on the site

[KIN-349]: https://loopcrack.atlassian.net/browse/KIN-349?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ